### PR TITLE
Added "accept cookies" option

### DIFF
--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -59,6 +59,13 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_accept_cookies"
+        android:title="@string/acceptCookies"
+        android:checkable="true"
+        android:checked="true"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_cast_to_kodi"
         android:enabled="false"
         android:title="@string/castToKodi"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,4 +22,5 @@
     <string name="share_with">Teilen mit…</string>
     <string name="menu">Menü</string>
     <string name="set_as_home">Als Startseite festlegen</string>
+    <string name="acceptCookies">Cookies akzeptieren</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="bookmarks">Bookmarks</string>
     <string name="openInBrowser">Open in browser</string>
     <string name="castToKodi">Cast to Kodi</string>
+    <string name="acceptCookies">Accept cookies</string>
     <string name="share">Share</string>
     <string name="enableTor">Enable Tor</string>
     <string name="disableTor">Disable Tor</string>


### PR DESCRIPTION
There have been several requests for an option to disable/delete cookies (e.g. in issues #16, #50 and #51).
I therefore decided to add an "accept cookies" checkbox to the menu.
For security reasons, I also made sure that this checkbox is automatically disabled when the user decides to use the Tor option.