### PR TITLE
Add a menu option to toggle forcing landscape orientation in fullscreen

### DIFF
--- a/app/src/main/java/cz/martykan/webtube/MainActivity.java
+++ b/app/src/main/java/cz/martykan/webtube/MainActivity.java
@@ -128,7 +128,7 @@ public class MainActivity extends AppCompatActivity {
                 new ComponentName(getPackageName(), MediaButtonIntentReceiver.class.getName()));
 
         // Set up WebChromeClient
-        webView.setWebChromeClient(new WebTubeChromeClient(webView, progress, customViewContainer, drawerLayout, getWindow().getDecorView()));
+        webView.setWebChromeClient(new WebTubeChromeClient(this, webView, progress, customViewContainer, drawerLayout, getWindow().getDecorView()));
 
         // Set up WebViewClient
         webView.setWebViewClient(new WebTubeWebViewClient(this, appWindow, clickListener, findViewById(R.id.statusBarSpace), findViewById(R.id.menu_main)));

--- a/app/src/main/java/cz/martykan/webtube/MenuHelper.java
+++ b/app/src/main/java/cz/martykan/webtube/MenuHelper.java
@@ -35,6 +35,7 @@ public class MenuHelper implements ActionMenuView.OnMenuItemClickListener {
     View bookmarksPanel;
 
     public static final String PREF_COOKIES_ENABLED = "cookiesEnabled";
+    public static final String PREF_LANDSCAPE_FULLSCREEN = "landscapeFullscreenEnabled";
 
     public MenuHelper(Context context, WebView webView, TorHelper torHelper, BackgroundPlayHelper backgroundPlayHelper, View appWindow) {
         this.context = context;
@@ -79,6 +80,7 @@ public class MenuHelper implements ActionMenuView.OnMenuItemClickListener {
 
         menu.findItem(R.id.action_backgroundPlay).setChecked(sp.getBoolean(BackgroundPlayHelper.PREF_BACKGROUND_PLAY_ENABLED, true));
         menu.findItem(R.id.action_accept_cookies).setChecked(sp.getBoolean(PREF_COOKIES_ENABLED,true));
+        menu.findItem(R.id.action_landscape_fullscreen).setChecked(sp.getBoolean(PREF_LANDSCAPE_FULLSCREEN,false));
 
         // Tor button
         if (OrbotHelper.isOrbotInstalled(context.getApplicationContext())) {
@@ -111,6 +113,8 @@ public class MenuHelper implements ActionMenuView.OnMenuItemClickListener {
 
     @Override
     public boolean onMenuItemClick(final MenuItem item) {
+        SharedPreferences.Editor spEdit = sp.edit();
+
         switch(item.getItemId()){
             case R.id.action_web:
                 context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(webView.getUrl())));
@@ -229,10 +233,19 @@ public class MenuHelper implements ActionMenuView.OnMenuItemClickListener {
                     CookieHelper.acceptCookies(webView,true);
                     item.setChecked(true);
                 }
-                SharedPreferences.Editor spEdit = sp.edit();
                 spEdit.putBoolean(PREF_COOKIES_ENABLED,!sp.getBoolean(PREF_COOKIES_ENABLED,true));
                 spEdit.commit();
                 return  true;
+
+            case R.id.action_landscape_fullscreen:
+                if (sp.getBoolean(PREF_LANDSCAPE_FULLSCREEN, false)) {
+                    item.setChecked(false);
+                } else {
+                    item.setChecked(true);
+                }
+                spEdit.putBoolean(PREF_LANDSCAPE_FULLSCREEN,!sp.getBoolean(PREF_LANDSCAPE_FULLSCREEN,false));
+                spEdit.commit();
+                return true;
         }
 
         return false;

--- a/app/src/main/java/cz/martykan/webtube/WebTubeChromeClient.java
+++ b/app/src/main/java/cz/martykan/webtube/WebTubeChromeClient.java
@@ -1,7 +1,11 @@
 package cz.martykan.webtube;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.support.v4.widget.DrawerLayout;
 import android.util.Log;
 import android.view.View;
@@ -12,21 +16,28 @@ import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
+import static cz.martykan.webtube.MenuHelper.PREF_LANDSCAPE_FULLSCREEN;
+
 public class WebTubeChromeClient extends WebChromeClient {
 
+    Activity activity;
     View mCustomView;
     ProgressBar progress;
     WebView webView;
     FrameLayout customViewContainer;
     DrawerLayout drawerLayout;
     View decorView;
+    SharedPreferences sp;
 
-    public WebTubeChromeClient(WebView webView, ProgressBar progress, FrameLayout customViewContainer, DrawerLayout drawerLayout, View decorView) {
+    public WebTubeChromeClient(Activity activity, WebView webView, ProgressBar progress, FrameLayout customViewContainer, DrawerLayout drawerLayout, View decorView) {
+        this.activity = activity;
         this.webView = webView;
         this.progress = progress;
         this.customViewContainer = customViewContainer;
         this.drawerLayout = drawerLayout;
         this.decorView = decorView;
+
+        sp = PreferenceManager.getDefaultSharedPreferences(activity);
     }
 
     // Fullscreen playback
@@ -48,6 +59,10 @@ public class WebTubeChromeClient extends WebChromeClient {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
         }
+
+        if (sp.getBoolean(PREF_LANDSCAPE_FULLSCREEN, false)) {
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        }
     }
 
     @Override
@@ -67,6 +82,8 @@ public class WebTubeChromeClient extends WebChromeClient {
 
         // Show the status bar.
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
     }
 
     // Progressbar

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -70,5 +70,11 @@
         android:enabled="false"
         android:title="@string/castToKodi"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_landscape_fullscreen"
+        android:checkable="true"
+        android:checked="false"
+        android:title="@string/landscapeFullscreen"
+        app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -38,43 +38,51 @@
         android:title="@string/set_as_home"
         app:showAsAction="never" />
 
-    <item
-        android:id="@+id/action_backgroundPlay"
-        android:checkable="true"
-        android:checked="true"
-        android:title="@string/playInBackground"
-        app:showAsAction="never" />
-
-    <item
-        android:id="@+id/action_tor"
-        android:checkable="true"
-        android:checked="false"
-        android:title="@string/enableTor"
-        android:enabled="false"
-        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_download"
         android:title="@string/download"
         app:showAsAction="never" />
 
-    <item
-        android:id="@+id/action_accept_cookies"
-        android:title="@string/acceptCookies"
-        android:checkable="true"
-        android:checked="true"
-        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_cast_to_kodi"
         android:enabled="false"
         android:title="@string/castToKodi"
         app:showAsAction="never" />
+
     <item
-        android:id="@+id/action_landscape_fullscreen"
-        android:checkable="true"
-        android:checked="false"
-        android:title="@string/landscapeFullscreen"
-        app:showAsAction="never" />
+        android:id="@+id/options_menu"
+        android:title="@string/options_menu">
+        <menu>
+            <item
+                android:id="@+id/action_backgroundPlay"
+                android:checkable="true"
+                android:checked="true"
+                android:title="@string/playInBackground"
+                app:showAsAction="never" />
+
+            <item
+                android:id="@+id/action_tor"
+                android:checkable="true"
+                android:checked="false"
+                android:title="@string/enableTor"
+                android:enabled="false"
+                app:showAsAction="never" />
+            <item
+                android:id="@+id/action_accept_cookies"
+                android:title="@string/acceptCookies"
+                android:checkable="true"
+                android:checked="true"
+                app:showAsAction="never" />
+
+            <item
+                android:id="@+id/action_landscape_fullscreen"
+                android:checkable="true"
+                android:checked="false"
+                android:title="@string/landscapeFullscreen"
+                app:showAsAction="never" />
+        </menu>
+    </item>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <string name="download">Download</string>
 
     <string name="landscapeFullscreen">Use landscape in fullscreen</string>
+    <string name="options_menu">Options</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,6 @@
     <string name="set_as_home">Set as home</string>
     <string name="playInBackground">Play in background</string>
     <string name="download">Download</string>
+
+    <string name="landscapeFullscreen">Use landscape in fullscreen</string>
 </resources>


### PR DESCRIPTION
My phone does not have a gyro, so I am stuck in portrait mode with no way to change orientation. So I've decided to add an option to lock the video in landscape when in fullscreen. I imagine this setting might be useful even if the user has a gyro, and just wants to watch videos in landscape without having to lock their global orientation.

In addition, I've created a submenu for Options (e.g. all the boolean menu items) to keep the main menu from being too cluttered.